### PR TITLE
Fix Docker Run Command to use 1.2.15 jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.2.10-SNAPSHOT-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.2.15-jar-with-dependencies.jar", "-d"]


### PR DESCRIPTION
In the last update to 1.2.15, the Dockerfile was not updated, so it was referencing the jar using an invalid name (looking for the 1.2.10-SNAPSHOT jar).  This commit updates the Dockerfile to reference the 1.2.15 jar.