### PR TITLE
Update info.cqframework libs to 1.2.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.2.18-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.2.20-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Executed via the command line:
 
-    java -jar target/cqlTranslationServer-1.0-SNAPSHOT-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.2.20-jar-with-dependencies.jar
 
 Example usage via HTTP request:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.18</version>
+  <version>1.2.20</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -54,32 +54,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.2.18</version>
+      <version>1.2.20</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.2.18</version>
+      <version>1.2.20</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.2.18</version>
+      <version>1.2.20</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.2.18</version>
+      <version>1.2.20</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.2.18</version>
+      <version>1.2.20</version>
     </dependency>
     <dependency>
 		<groupId>info.cqframework</groupId>
 		<artifactId>qdm</artifactId>
-		<version>1.2.18</version>
+		<version>1.2.20</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Updates the cql-to-elm lib and dependencies to the 1.2.20 version of cql-to-elm.

See the following release notes to review the incorporated changes:
* [CQL 1.2 (v1.2.20)](https://github.com/cqframework/clinical_quality_language/releases/tag/v1.2.20)
* [CQL 1.2 (v1.2.19)](https://github.com/cqframework/clinical_quality_language/releases/tag/v1.2.19)