### PR TITLE
Updated for 1.3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.20</version>
+  <version>1.3.8</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -54,32 +54,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.2.20</version>
+      <version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.2.20</version>
+      <version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.2.20</version>
+      <version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.2.20</version>
+      <version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.2.20</version>
+      <version>1.3.8</version>
     </dependency>
     <dependency>
 		<groupId>info.cqframework</groupId>
 		<artifactId>qdm</artifactId>
-		<version>1.2.20</version>
+		<version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -95,7 +95,7 @@ public class TranslationResource {
       List<Options> optionsList = new ArrayList<Options>();
       optionsList.add(Options.EnableAnnotations);
       if (disablePromotion) {
-        optionsList.add(Options.DisablePromotion);
+        optionsList.add(Options.DisableListPromotion);
       }
       Options[] options = optionsList.toArray(new Options[optionsList.size()]);
       return CqlTranslator.fromFile(cql, modelManager, libraryManager, options);


### PR DESCRIPTION
Updated to use 1.3.8 releases.
 - Changed promotion option to match changes in cql-to-elm.