### PR TITLE
Translator Updates (Docker, Options, v1.3.15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target/
 /.idea
 /*.iml
+/.settings
+/.classpath
+/.project
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.3.10-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.3.15-jar-with-dependencies.jar", "-d"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.3.9-jdk-8
+FROM maven:3.6.1-jdk-8
 
 # application placed into /opt/app
 RUN mkdir -p /app

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Executed via the command line:
 
-    java -jar target/cqlTranslationServer-1.3.10-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.3.15-jar-with-dependencies.jar
 
 Example usage via HTTP request:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Build:
 
     mvn package
 
-Executed via the command line:
+Execute via the command line:
 
     java -jar target/cqlTranslationServer-1.3.15-jar-with-dependencies.jar
+
+## Simple Request
 
 Example usage via HTTP request:
 
@@ -26,7 +28,7 @@ Example usage via HTTP request:
     valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.102.12.1011'
     ...
 
-Will return
+Will return:
 
     HTTP/1.1 200 OK
     Content-Type: application/elm+json
@@ -61,9 +63,116 @@ Will return
       }
     }
 
+## Multipart Request
+
 The service also supports `POST` of multiple CQL libraries packaged as
 `multipart/form-data`. The result will be a similar package with one ELM part for each
 CQL part in the submitted package.
+
+Example usage via HTTP request:
+
+    POST /cql/translator HTTP/1.1
+    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Accept: multipart/form-data
+    Host: localhost:8080
+    content-length: 545
+    Connection: keep-alive
+
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--,
+    Content-Disposition: form-data; name="HelloWorld"
+
+    library HelloWorld version '1.0.0'
+
+    using QDM
+
+    include Speaker version '1.0.0' called Speaker
+
+    define Hello: 'World'
+
+    define SpeakerName: Speaker.Name
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    Content-Disposition: form-data; name="Speaker"
+
+    library Speaker version '1.0.0'
+
+    using QDM
+
+    define Name: 'Bob'
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+
+Will return:
+
+    HTTP/1.1 200
+    status: 200
+    MIME-Version: 1.0
+    Content-Type: multipart/form-data;boundary=Boundary_2_526521536_1556163069788
+    Date: Thu, 25 Apr 2019 03:47:49 GMT
+    Content-Length: 2365
+
+    --Boundary_2_526521536_1556163069788
+    Content-Type: application/elm+json
+    Content-Disposition: form-data; name="HelloWorld"
+
+    {
+      "library" : {
+          "identifier" : {
+            "id" : "HelloWorld",
+            "version" : "1.0.0"
+          },
+          "schemaIdentifier" : {
+            "id" : "urn:hl7-org:elm",
+            "version" : "r1"
+          },
+          ...
+      }
+    }
+    --Boundary_2_526521536_1556163069788
+    Content-Type: application/elm+json
+    Content-Disposition: form-data; name="Speaker"
+
+    {
+      "library" : {
+          "identifier" : {
+            "id" : "Speaker",
+            "version" : "1.0.0"
+          },
+          "schemaIdentifier" : {
+            "id" : "urn:hl7-org:elm",
+            "version" : "r1"
+          },
+          ...
+      }
+    }
+    --Boundary_2_526521536_1556163069788--
+
+## CQL-to-ELM Options
+
+The CQL-to-ELM translator supports many options to control the output.  These options can be passed to the service as query parameters when you post CQL to the service (e.g., `POST http://localhost:8080/cql/translator?annotations=true&result-types=true`).  These query parameters are supported for both simple requests and multipart requests.  See the table below for the available options:
+
+|Option|Values|Default|
+|----|----|----|
+|date-range-optimization|true\|false|false|
+|annotations|true\|false|false|
+|locators|true\|false|false|
+|result-types|true\|false|false|
+|signatures|None\|Differing\|Overloads\|All|None|
+|detailed-errors|true\|false|false|
+|disable-list-traversal|true\|false|false|
+|disable-list-demotion|true\|false|false|
+|disable-list-promotion|true\|false|false|
+|enable-interval-demotion|true\|false|false|
+|enable-interval-promotion|true\|false|false|
+|disable-method-invocation|true\|false|false|
+|require-from-keyword|true\|false|false|
+|strict|true\|false|false|
+|debug|true\|false|false|
+|validate-units|true\|false|false|
+
+For more information on each of these options, see the [CQL-to-ELM Overview](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/OVERVIEW.md#usage).
+
+_**NOTE:**_
+* _Previous versions of the CQL-to-ELM Translation Service defaulted **annotations** to true.  To align better with the CQL-to-ELM console client, the translation service now defaults annotations to false._
+* _Previous versions of the CQL-to-ELM Translation Service allowed list-promotion to be disabled via an extra multipart form field named **disablePromotion**. This is no longer supported, as it was ambiguous and inconsistent with the CQL-to-ELM console clinet.  The **disable-list-promotion** query parameter should be used instead._
 
 ## Docker Deployment
 
@@ -71,7 +180,7 @@ You may deploy pre-built Docker images into your existing hosting environment wi
 
 	docker run -d -p 8080:8080 --restart unless-stopped cqframework/cql-translation-service:latest # or any official tag
 
-And you're done. No environment variables or further configuration are needed. Jedi's may use your existing Kubernetes, Open Shift etc installations as you see fit. :)
+And you're done. No environment variables or further configuration are needed. Jedis may use your existing Kubernetes, Open Shift etc installations as you see fit. :)
 
 To build your own image:
 
@@ -79,7 +188,7 @@ To build your own image:
 
 ## License
 
-Copyright 2016-2017 The MITRE Corporation
+Copyright 2016-2019 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.10</version>
+  <version>1.3.15</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -54,32 +54,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
 		<groupId>info.cqframework</groupId>
 		<artifactId>qdm</artifactId>
-		<version>1.3.10</version>
+		<version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationFailureException.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationFailureException.java
@@ -18,6 +18,8 @@ import org.cqframework.cql.elm.tracking.TrackBack;
  */
 public class TranslationFailureException extends WebApplicationException {
 
+  private static final long serialVersionUID = 3188788471978609249L;
+
   public TranslationFailureException(String msg) {
     super(Response.status(Response.Status.BAD_REQUEST)
             .type(MediaType.TEXT_PLAIN_TYPE)

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -2,6 +2,7 @@ package org.mitre.bonnie.cqlTranslationServer;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.io.File;
 import java.io.IOException;
 import javax.ws.rs.Consumes;
@@ -10,17 +11,25 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
+import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
+import org.fhir.ucum.UcumEssenceService;
+import org.fhir.ucum.UcumException;
+import org.fhir.ucum.UcumService;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
 
 /**
  * Root resource (exposed at "translator" path). Uses default per-request
@@ -29,10 +38,35 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
  */
 @Path("translator")
 public class TranslationResource {
-  
+
   public static final String CQL_TEXT_TYPE = "application/cql";
   public static final String ELM_XML_TYPE = "application/elm+xml";
   public static final String ELM_JSON_TYPE = "application/elm+json";
+  public static final MultivaluedMap<String, Options> PARAMS_TO_OPTIONS_MAP = new MultivaluedHashMap<String, Options>() {{
+    putSingle("date-range-optimization", Options.EnableDateRangeOptimization);
+    putSingle("annotations", Options.EnableAnnotations);
+    putSingle("locators", Options.EnableLocators);
+    putSingle("result-types", Options.EnableResultTypes);
+    putSingle("detailed-errors", Options.EnableDetailedErrors);
+    putSingle("disable-list-traversal", Options.DisableListTraversal);
+    putSingle("disable-list-demotion", Options.DisableListDemotion);
+    putSingle("disable-list-promotion", Options.DisableListPromotion);
+    putSingle("enable-interval-demotion", Options.EnableIntervalDemotion);
+    putSingle("enable-interval-promotion", Options.EnableIntervalPromotion);
+    putSingle("disable-method-invocation", Options.DisableMethodInvocation);
+    putSingle("require-from-keyword", Options.RequireFromKeyword);
+    put("strict", Arrays.asList(
+            Options.DisableListTraversal,
+            Options.DisableListDemotion,
+            Options.DisableListPromotion,
+            Options.DisableMethodInvocation)
+    );
+    put("debug", Arrays.asList(
+            Options.EnableAnnotations,
+            Options.EnableLocators,
+            Options.EnableResultTypes)
+    );
+  }};
   private final ModelManager modelManager;
   private final LibraryManager libraryManager;
 
@@ -40,12 +74,12 @@ public class TranslationResource {
     this.modelManager = new ModelManager();
     this.libraryManager = new LibraryManager(modelManager);
   }
-  
+
   @POST
   @Consumes(CQL_TEXT_TYPE)
   @Produces(ELM_XML_TYPE)
-  public Response cqlToElmXml(File cql) {
-    CqlTranslator translator = getTranslator(cql);
+  public Response cqlToElmXml(File cql, @Context UriInfo info) {
+    CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
     ResponseBuilder resp = getResponse(translator);
     resp = resp.entity(translator.toXml()).type(ELM_XML_TYPE);
     return resp.build();
@@ -54,26 +88,28 @@ public class TranslationResource {
   @POST
   @Consumes(CQL_TEXT_TYPE)
   @Produces(ELM_JSON_TYPE)
-  public Response cqlToElmJson(File cql) {
-    CqlTranslator translator = getTranslator(cql);
+  public Response cqlToElmJson(File cql, @Context UriInfo info) {
+    CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
     ResponseBuilder resp = getResponse(translator);
     resp = resp.entity(translator.toJson()).type(ELM_JSON_TYPE);
     return resp.build();
   }
-  
+
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.MULTIPART_FORM_DATA)
-  public Response cqlPackageToElmPackage(FormDataMultiPart pkg, 
+  public Response cqlPackageToElmPackage(
+          FormDataMultiPart pkg,
           @HeaderParam("X-TargetFormat") @DefaultValue(ELM_JSON_TYPE) MediaType targetFormat,
-                                         @DefaultValue("false") @FormDataParam("disablePromotion") boolean disablePromotion) {
+          @Context UriInfo info
+  ) {
     try {
       FormDataMultiPart translatedPkg = new FormDataMultiPart();
       MultipartLibrarySourceProvider lsp = new MultipartLibrarySourceProvider(pkg);
       libraryManager.getLibrarySourceLoader().registerProvider(lsp);
       for (String fieldId: pkg.getFields().keySet()) {
-        for (FormDataBodyPart part: pkg.getFields(fieldId)){
-          CqlTranslator translator = getTranslator(part.getEntityAs(File.class), disablePromotion);
+        for (FormDataBodyPart part: pkg.getFields(fieldId)) {
+          CqlTranslator translator = getTranslator(part.getEntityAs(File.class), info.getQueryParameters());
           if (targetFormat.equals(MediaType.valueOf(ELM_XML_TYPE))) {
             translatedPkg.field(fieldId, translator.toXml(), targetFormat);
           } else {
@@ -88,31 +124,38 @@ public class TranslationResource {
     }
   }
 
-  private CqlTranslator getTranslator(File cql, boolean disablePromotion) {
+  private CqlTranslator getTranslator(File cql, MultivaluedMap<String, String> params) {
     try {
       //LibrarySourceLoader.registerProvider(
       //        new DefaultLibrarySourceProvider(cql.toPath().getParent()));
-      List<Options> optionsList = new ArrayList<Options>();
-      optionsList.add(Options.EnableAnnotations);
-      if (disablePromotion) {
-        optionsList.add(Options.DisableListPromotion);
+      UcumService ucumService = null;
+      LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
+      List<Options> optionsList = new ArrayList<>();
+      for (String key: params.keySet()) {
+        if (PARAMS_TO_OPTIONS_MAP.containsKey(key) && Boolean.parseBoolean(params.getFirst(key))) {
+          optionsList.addAll(PARAMS_TO_OPTIONS_MAP.get(key));
+        } else if (key.equals("validate-units") && Boolean.parseBoolean(params.getFirst(key))) {
+          try {
+            ucumService = new UcumEssenceService(UcumEssenceService.class.getResourceAsStream("/ucum-essence.xml"));
+          } catch (UcumException e) {
+            throw new TranslationFailureException("Cannot load UCUM service to validate units");
+          }
+        } else if (key.equals("signatures")) {
+          signatureLevel = LibraryBuilder.SignatureLevel.valueOf(params.getFirst("signatures"));
+        }
       }
       Options[] options = optionsList.toArray(new Options[optionsList.size()]);
-      return CqlTranslator.fromFile(cql, modelManager, libraryManager, options);
+      return CqlTranslator.fromFile(cql, modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info,
+              signatureLevel, options);
       //LibrarySourceLoader.clearProviders();
     } catch (IOException e) {
       throw new TranslationFailureException("Unable to read request");
     }
   }
 
-  private CqlTranslator getTranslator(File cql) {
-    return getTranslator(cql, false);
-  }
-
   private ResponseBuilder getResponse(CqlTranslator translator) {
-    ResponseBuilder resp = translator.getErrors().size() > 0
+    return translator.getErrors().size() > 0
             ? Response.status(Status.BAD_REQUEST) : Response.ok();
-    return resp;
   }
 
 }


### PR DESCRIPTION
**This PR contains the following changes:**

* Updates the base Docker image to maven:3.6.1-jdk-8, which has been confirmed to use OpenJDK
* Updates the CQL-to-ELM translator from v1.3.10 to v1.3.15
* Adds support for all of the potentially relevant CQL-to-ELM options via query parameters

**NOTE SOME BREAKING CHANGES:**

* Prior versions enabled annotations by default.  This was inconsistent w/ the CQL-to-ELM library and console client.  For consistency's sake, this version has annotations disabled by default.
* Prior versions allowed list promotion to be disabled via a `disablePromotion` form field in multipart requests.  This was ambiguous (as there is now list promotion _and_ interval promotion), and it *required* the more complex multi-part request, even if you were translating only one file.  This is no longer supported.  Use the `disable-list-promotion` query parameter instead.

See the README for details on using the CQL-to-ELM query parameters.

@jbradl11 -- you're requested for review since Bonnie is a user of this service.  Feel free to assign to someone else on the Bonnie team.
@brynrhodes -- you're requested for review since you are the primary maintainer of CQL-to-ELM.