### PR TITLE
FHIR library source provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.3.15-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.3.17-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.3.15-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.3.17-jar-with-dependencies.jar
 
 ## Simple Request
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.15</version>
+  <version>1.3.17</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -54,32 +54,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
 		<groupId>info.cqframework</groupId>
 		<artifactId>qdm</artifactId>
-		<version>1.3.15</version>
+		<version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -80,20 +80,30 @@ public class TranslationResource {
   @Consumes(CQL_TEXT_TYPE)
   @Produces(ELM_XML_TYPE)
   public Response cqlToElmXml(File cql, @Context UriInfo info) {
-    CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
-    ResponseBuilder resp = getResponse(translator);
-    resp = resp.entity(translator.toXml()).type(ELM_XML_TYPE);
-    return resp.build();
+    try {
+      libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+      CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
+      ResponseBuilder resp = getResponse(translator);
+      resp = resp.entity(translator.toXml()).type(ELM_XML_TYPE);
+      return resp.build();
+    } finally {
+      libraryManager.getLibrarySourceLoader().clearProviders();
+    }
   }
 
   @POST
   @Consumes(CQL_TEXT_TYPE)
   @Produces(ELM_JSON_TYPE)
   public Response cqlToElmJson(File cql, @Context UriInfo info) {
-    CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
-    ResponseBuilder resp = getResponse(translator);
-    resp = resp.entity(translator.toJson()).type(ELM_JSON_TYPE);
-    return resp.build();
+    try {
+      libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+      CqlTranslator translator = getTranslator(cql, info.getQueryParameters());
+      ResponseBuilder resp = getResponse(translator);
+      resp = resp.entity(translator.toJson()).type(ELM_JSON_TYPE);
+      return resp.build();
+    } finally {
+      libraryManager.getLibrarySourceLoader().clearProviders();
+    }
   }
 
   @POST

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -115,10 +115,11 @@ public class TranslationResource {
           @Context UriInfo info
   ) {
     try {
-      FormDataMultiPart translatedPkg = new FormDataMultiPart();
+      // note: if FhirLibrarySourceProvider isn't registered first it doesn't seem to work
+      libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
       MultipartLibrarySourceProvider lsp = new MultipartLibrarySourceProvider(pkg);
       libraryManager.getLibrarySourceLoader().registerProvider(lsp);
-      libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+      FormDataMultiPart translatedPkg = new FormDataMultiPart();
       for (String fieldId: pkg.getFields().keySet()) {
         for (FormDataBodyPart part: pkg.getFields(fieldId)) {
           CqlTranslator translator = getTranslator(part.getEntityAs(File.class), info.getQueryParameters());

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.UriInfo;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
 import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
@@ -107,6 +108,7 @@ public class TranslationResource {
       FormDataMultiPart translatedPkg = new FormDataMultiPart();
       MultipartLibrarySourceProvider lsp = new MultipartLibrarySourceProvider(pkg);
       libraryManager.getLibrarySourceLoader().registerProvider(lsp);
+      libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
       for (String fieldId: pkg.getFields().keySet()) {
         for (FormDataBodyPart part: pkg.getFields(fieldId)) {
           CqlTranslator translator = getTranslator(part.getEntityAs(File.class), info.getQueryParameters());
@@ -121,6 +123,8 @@ public class TranslationResource {
       return resp.build();
     } catch (IOException ex) {
       throw new TranslationFailureException("Unable to read request");
+    } finally {
+      libraryManager.getLibrarySourceLoader().clearProviders();
     }
   }
 


### PR DESCRIPTION
Enables the use of FHIRHelpers in the service (both implicit and explicit) by adding the FhirLibrarySourceProvider to the library manager in the `cqlToElmXml`, `cqlToElmJson`, and `cqlPackageToElmPackage` functions. Per a recommendation from @cmoesel I also added a `finally` block that ensures the libraries are cleared out after each request.  Also includes a few changes @cmoesel made to bump versions.

Testing was performed manually using the sample CQL here: https://github.com/cqframework/cql-exec-examples/blob/master/diabetic-foot-exam/r4/cql/DiabeticFootExam.cql 
Before the changes, this service will return a number of errors for this CQL, listed below. With the changes, the service returns no errors, as expected.

This PR is based on observing the difference between the service and the CLI CQL-to-ELM converter, specifically here: https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java#L470