### PR TITLE
Update to CQL-to-ELM 1.4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.3.17-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.4.6-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.3.17-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.4.6-jar-with-dependencies.jar
 
 ## Simple Request
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.17</version>
+  <version>1.4.6</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -59,32 +59,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.3.17</version>
+      <version>1.4.6</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.3.17</version>
+      <version>1.4.6</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.3.17</version>
+      <version>1.4.6</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.3.17</version>
+      <version>1.4.6</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.3.17</version>
+      <version>1.4.6</version>
     </dependency>
     <dependency>
 		<groupId>info.cqframework</groupId>
 		<artifactId>qdm</artifactId>
-		<version>1.3.17</version>
+		<version>1.4.6</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/MultipartLibrarySourceProvider.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/MultipartLibrarySourceProvider.java
@@ -60,16 +60,16 @@ public class MultipartLibrarySourceProvider implements LibrarySourceProvider {
 
     public VersionedIdentifier getLibraryId() {
       return vid;
-    } 
+    }
 
     @Override
     public VersionedIdentifier visitLibraryDefinition(@NotNull cqlParser.LibraryDefinitionContext ctx) {
       vid = of.createVersionedIdentifier()
-              .withId(parseString(ctx.identifier()))
+              .withId(parseString(ctx.qualifiedIdentifier().identifier()))
               .withVersion(parseString(ctx.versionSpecifier()));
       return vid;
     }
-    
+
     @Override
     public Object visitTerminal(@NotNull TerminalNode node) {
       String text = node.getText();


### PR DESCRIPTION
This also includes a slight tweak to the Java code for extracting a library's identifier.