### PR TITLE
Upgrade CQL-to-ELM to 1.5.2

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -14,4 +14,4 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn package
+        run: mvn --batch-mode verify

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn package

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.4.9-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.5.2-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.4.9-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.5.2-jar-with-dependencies.jar
 
 ## Simple Request
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.9</version>
+  <version>1.5.2</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -70,32 +70,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.4.9</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.4.9</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.4.9</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.4.9</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.4.9</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>qdm</artifactId>
-		  <version>1.4.9</version>
+		  <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -65,7 +65,7 @@ public class TranslationResourceTest {
     // dependency on jersey-media-json module in pom.xml and Main.startServer())
     // --
     // c.configuration().enable(new org.glassfish.jersey.media.json.JsonJaxbFeature());
-    target = c.target(Main.BASE_URI);
+    target = c.target(Main.BASE_URI.replace("0.0.0.0", "localhost"));
   }
 
   @After
@@ -232,7 +232,7 @@ public class TranslationResourceTest {
     JsonObject obj = reader.readObject();
     JsonObject library = obj.getJsonObject("library");
     JsonArray annotations = library.getJsonArray("annotation");
-    assertEquals(1, annotations.size());
+    assertEquals(2, annotations.size());
     JsonObject identifier = library.getJsonObject("identifier");
     assertEquals("CMS146", identifier.getString("id"));
     assertEquals("2", identifier.getString("version"));
@@ -360,13 +360,13 @@ public class TranslationResourceTest {
         	parseAndValidateXml( part, "CMS146", "2", 0 );
         } else if( part.getMediaType().equals( MediaType.valueOf( TranslationResource.ELM_JSON_TYPE ) ) ) {
         	parseAndValidateJson( part, "CMS146", "2", 0 );
-        } else { 
+        } else {
           fail( "Unsupported media type" );
         }
       }
     }
   }
-  
+
   private Document parseAndValidateXml( BodyPart input, String expectedId, String expectedVersion, int expectedErrors ) throws Exception {
       Document doc = parseXml(input.getEntityAs(String.class));
       String errorCount = applyXPath(doc, "count(/elm:library/elm:annotation[@errorType='syntax'])");
@@ -375,13 +375,13 @@ public class TranslationResourceTest {
       assertEquals("2", applyXPath(doc, "/elm:library/elm:identifier/@version") );
       return doc;
   }
-  
+
   private JsonObject parseAndValidateJson( BodyPart input, String expectedId, String expectedVersion, int expectedErrors ) {
       JsonReader reader = Json.createReader( new StringReader(input.getEntityAs(String.class)) );
       JsonObject obj = reader.readObject();
       JsonObject library = obj.getJsonObject("library");
       JsonArray annotations = library.getJsonArray("annotation");
-      if( expectedErrors == 0 ) { 
+      if( expectedErrors == 0 ) {
     	  assertEquals(1, annotations.size() );
       } else {
     	  assertEquals( expectedErrors + 1, annotations.size() );
@@ -389,7 +389,7 @@ public class TranslationResourceTest {
       JsonObject identifier = library.getJsonObject("identifier");
       assertEquals( expectedId, identifier.getString("id"));
       assertEquals( expectedVersion, identifier.getString("version"));
-      
+
       return library;
   }
 


### PR DESCRIPTION
Updated the underlying libraries to use version 1.5.2 of the CQL-to-ELM translator.

This required a slight tweak to the tests because trying to connect the test client to `0.0.0.0` was causing `NoRouteToHostException` -- which I was able to resolve by changing `0.0.0.0` to `localhost`.

I also had to update one test to expect an additional annotation due to CQL-to-ELM now providing a translation options annotation.

_BTW: Since this is the first 1.5.x update, I've also created a new `1.4.x` branch to track any 1.4.x bug fixes as needed._