### PR TITLE
Adds support for configuring the server port via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ To build your own image:
 
 	docker build -t cqframework/cql-translation-service:latest . # but use your your own repo and tag strings!
 
+## Environment Variables
+
+**CQL_TRANSLATOR_PORT** - Allows you to set the port on which the translation service runs, default value is 8080
+
 ## License
 
 Copyright 2016-2019 The MITRE Corporation

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/Main.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/Main.java
@@ -26,7 +26,7 @@ public class Main {
   // Base URI the Grizzly HTTP server will listen on
 
   // Must be 0.0.0.0 and not "localhost" to allow binding to other available network interfaces.
-  public static final String BASE_URI = "http://0.0.0.0:8080/cql/";
+  public static final String BASE_URI = String.format("http://0.0.0.0:%s/cql", System.getenv().getOrDefault("PORT", "8080"));
 
   /**
    * Starts Grizzly HTTP server exposing JAX-RS resources defined in this

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/Main.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/Main.java
@@ -26,7 +26,7 @@ public class Main {
   // Base URI the Grizzly HTTP server will listen on
 
   // Must be 0.0.0.0 and not "localhost" to allow binding to other available network interfaces.
-  public static final String BASE_URI = String.format("http://0.0.0.0:%s/cql", System.getenv().getOrDefault("PORT", "8080"));
+  public static final String BASE_URI = String.format("http://0.0.0.0:%s/cql", System.getenv().getOrDefault("CQL_TRANSLATOR_PORT", "8080"));
 
   /**
    * Starts Grizzly HTTP server exposing JAX-RS resources defined in this


### PR DESCRIPTION
I think it would be helpful if we could configure the port this service runs on with out having to change the code.
if this change is accepted , you will be able to set the `PORT` environment variable to control which port the service is bound

If this is already supported or there is a better way to do this , please share

Thank you for the awesome work.