### PR TITLE
Bump version of org.jboss.resteasy.resteasy-jaxrs to mitigate CVE-2020-1695

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.9.3.Final</version>
+      <version>3.12.1.Final</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Running synk against this repo highlighted that it could be vulnerable to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1695 


