### PR TITLE
Upgrade resteasy-jaxrs dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.9.3.Final</version>
+      <version>3.11.0.Final</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Updating the `resteasy-jaxrs` dependency version to version `3.11.0.Final` to fix an [input validation issue](https://app.snyk.io/vuln/SNYK-JAVA-ORGJBOSSRESTEASY-609370) that could result in header injection 