### PR TITLE
CQL Formatter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.5.2-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.5.2-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar
 
 ## Simple Request
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CQL to ELM Translation Service
 
-A microservice wrapper for the CQL to ELM conversion library.
+A microservice wrapper for the CQL to ELM conversion library and CQL formatter.
 
 Build:
 
@@ -10,7 +10,11 @@ Execute via the command line:
 
     java -jar target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar
 
-## Simple Request
+## Translator Endpoint
+
+The `/cql/translator` endpoint handles translating CQL to ELM JSON and/or XML.
+
+### Simple Translator Request
 
 Example usage via HTTP request:
 
@@ -63,7 +67,7 @@ Will return:
       }
     }
 
-## Multipart Request
+### Multipart Translator Request
 
 The service also supports `POST` of multiple CQL libraries packaged as
 `multipart/form-data`. The result will be a similar package with one ELM part for each
@@ -145,7 +149,7 @@ Will return:
     }
     --Boundary_2_526521536_1556163069788--
 
-## CQL-to-ELM Options
+### CQL-to-ELM Translator Options
 
 The CQL-to-ELM translator supports many options to control the output.  These options can be passed to the service as query parameters when you post CQL to the service (e.g., `POST http://localhost:8080/cql/translator?annotations=true&result-types=true`).  These query parameters are supported for both simple requests and multipart requests.  See the table below for the available options:
 
@@ -174,6 +178,97 @@ _**NOTE:**_
 * _Previous versions of the CQL-to-ELM Translation Service defaulted **annotations** to true.  To align better with the CQL-to-ELM console client, the translation service now defaults annotations to false._
 * _Previous versions of the CQL-to-ELM Translation Service allowed list-promotion to be disabled via an extra multipart form field named **disablePromotion**. This is no longer supported, as it was ambiguous and inconsistent with the CQL-to-ELM console clinet.  The **disable-list-promotion** query parameter should be used instead._
 
+## Formatter Endpoint
+
+The `/cql/formatter` endpoint handles reformatting CQL for improved consistency and readability.
+
+### Simple Formatter Request
+
+Example usage via HTTP request:
+
+    POST /cql/formatter HTTP/1.1
+    Content-Type: application/cql
+    Accept: application/cql
+    Host: localhost:8080
+    Content-Length: 50
+
+    library HelloWorld using QDM define Hello: 'World'
+
+Will return:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/cql
+    Content-Length: 59
+
+    library HelloWorld
+
+    using QDM
+
+    define Hello:
+      'World'
+
+### Multipart Formatter Request
+
+The service also supports `POST` of multiple CQL libraries packaged as
+`multipart/form-data`. The result will be a similar package with one
+formatted part for each CQL part in the submitted package.
+
+Example usage via HTTP request:
+
+
+    POST /cql/formatter HTTP/1.1
+    Host: localhost:8080
+    Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY
+    Accept: multipart/form-data
+    Content-Length: 465
+
+    --X-INSOMNIA-BOUNDARY
+    Content-Disposition: form-data; name="Simple.cql"
+    library "SimpleLibrary" version '0.0.1' using FHIR version '4.0.1'
+    include "FHIRHelpers" version '4.0.1' called FHIRHelpers
+    context Patient define "MeaningOfLife": 42
+    --X-INSOMNIA-BOUNDARY
+    Content-Disposition: form-data; name="FHIRHelpers.cql"
+    library FHIRHelpers version '4.0.1' using FHIR version '4.0.1'
+    context Patient define "IsFakeFHIRHelpers": true
+    --X-INSOMNIA-BOUNDARY--
+
+Will return:
+
+    HTTP/1.1 200 OK
+    MIME-Version: 1.0
+    Content-Type: multipart/form-data;boundary=Boundary_2_1638692479_1658770032240
+    Content-Length: 600
+
+    --Boundary_2_1638692479_1658770032240
+    Content-Type: application/cql
+    Content-Disposition: form-data; name="FHIRHelpers.cql"
+
+    library FHIRHelpers version '4.0.1'
+
+    using FHIR version '4.0.1'
+
+    context Patient
+
+    define "IsFakeFHIRHelpers":
+      true
+    --Boundary_2_1638692479_1658770032240
+    Content-Type: application/cql
+    Content-Disposition: form-data; name="Simple.cql"
+
+    library "SimpleLibrary" version '0.0.1'
+
+    using FHIR version '4.0.1'
+
+    include "FHIRHelpers" version '4.0.1' called FHIRHelpers
+
+    context Patient
+
+    define "MeaningOfLife":
+      42
+    --Boundary_2_1638692479_1658770032240--
+
+
 ## Docker Deployment
 
 You may deploy pre-built Docker images into your existing hosting environment with:
@@ -192,7 +287,7 @@ To build your own image:
 
 ## License
 
-Copyright 2016-2019 The MITRE Corporation
+Copyright 2016-2022 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
 		  <version>1.5.10</version>
     </dependency>
     <dependency>
+		  <groupId>info.cqframework</groupId>
+		  <artifactId>cql-formatter</artifactId>
+		  <version>1.5.10</version>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.2</version>
+  <version>1.5.10</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -70,32 +70,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.10</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.10</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.10</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.10</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.10</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>qdm</artifactId>
-		  <version>1.5.2</version>
+		  <version>1.5.10</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatFailureException.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatFailureException.java
@@ -1,0 +1,34 @@
+package org.mitre.bonnie.cqlTranslationServer;
+
+import java.util.List;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public class FormatFailureException extends WebApplicationException {
+
+  private static final long serialVersionUID = 4299899582089710350L;
+
+  public FormatFailureException(String msg) {
+    super(Response.status(Response.Status.BAD_REQUEST)
+            .type(MediaType.TEXT_PLAIN_TYPE)
+            .entity(msg)
+            .build());
+  }
+
+  public FormatFailureException(List<Exception> formatErrs) {
+    super(Response.status(Response.Status.BAD_REQUEST)
+            .type(MediaType.TEXT_PLAIN_TYPE)
+            .entity(formatMsg(formatErrs))
+            .build());
+  }
+
+  private static String formatMsg(List<Exception> formatErrs) {
+    StringBuilder msg = new StringBuilder();
+    msg.append("CQL formatting failed due to errors:");
+    for (Exception error : formatErrs) {
+      msg.append(error.getMessage()).append("\n");
+    }
+    return msg.toString();
+  }
+}

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
@@ -20,9 +20,7 @@ import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 
 /**
- * Root resource (exposed at "formatter" path). Uses default per-request
- * life cycle so a new CQL LibraryManager is instantiated and used for each
- * request that can include a batch of related CQL files.
+ * Root resource (exposed at "formatter" path).
  */
 @Path("formatter")
 public class FormatterResource {

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
@@ -1,0 +1,92 @@
+package org.mitre.bonnie.cqlTranslationServer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+import org.cqframework.cql.tools.formatter.CqlFormatterVisitor;
+import org.cqframework.cql.tools.formatter.CqlFormatterVisitor.FormatResult;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+
+/**
+ * Root resource (exposed at "formatter" path). Uses default per-request
+ * life cycle so a new CQL LibraryManager is instantiated and used for each
+ * request that can include a batch of related CQL files.
+ */
+@Path("formatter")
+public class FormatterResource {
+
+  public static final String CQL_TEXT_TYPE = "application/cql";
+  public static final String TARGET_FORMAT = "X-TargetFormat";
+
+  @POST
+  @Consumes(CQL_TEXT_TYPE)
+  @Produces(CQL_TEXT_TYPE)
+  public Response format(File cql, @Context UriInfo info) {
+    FileInputStream is = null;
+    try {
+      is = new FileInputStream(cql);
+      FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+      if( result.getErrors() != null && result.getErrors().size() > 0 ) {
+        throw new FormatFailureException(result.getErrors());
+      }
+      return Response.ok().entity(result.getOutput()).type(CQL_TEXT_TYPE).build();
+    } catch (IOException e) {
+        throw new FormatFailureException(String.format("CQL format failed: %s", e.toString()));
+    } finally {
+      if (is != null) {
+        try { is.close(); } catch( IOException iex ) { }
+      }
+    }
+  }
+
+  @POST
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.MULTIPART_FORM_DATA)
+  public Response cqlPackageToElmPackage(
+          FormDataMultiPart pkg,
+          @HeaderParam(TARGET_FORMAT) @DefaultValue(CQL_TEXT_TYPE) MediaType targetFormat,
+          @Context UriInfo info
+  ) {
+    if (!targetFormat.equals(MediaType.valueOf(CQL_TEXT_TYPE))) {
+      throw new FormatFailureException(
+        String.format("Unsupported media type: %s. Must be application/cql.", targetFormat.toString())
+      );
+    }
+    try {
+      FormDataMultiPart translatedPkg = new FormDataMultiPart();
+      for (String fieldId: pkg.getFields().keySet()) {
+        for (FormDataBodyPart part: pkg.getFields(fieldId)) {
+          FileInputStream is = null;
+          try {
+            is = new FileInputStream(part.getEntityAs(File.class));
+            FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+            if( result.getErrors() != null && result.getErrors().size() > 0 ) {
+                throw new FormatFailureException(result.getErrors());
+            }
+            translatedPkg.field(fieldId, result.getOutput(), targetFormat);
+          } finally {
+            if (is != null) {
+              try { is.close(); } catch( IOException iex ) { }
+            }
+          }
+        }
+      }
+      ResponseBuilder resp = Response.ok().type(MediaType.MULTIPART_FORM_DATA).entity(translatedPkg);
+      return resp.build();
+    } catch (IOException e) {
+      throw new FormatFailureException(String.format("CQL format failed: %s", e.toString()));
+    }
+  }
+}

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/FormatterResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/FormatterResourceTest.java
@@ -1,0 +1,161 @@
+package org.mitre.bonnie.cqlTranslationServer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FormatterResourceTest {
+
+  private HttpServer server;
+  private WebTarget target;
+
+  // The CQL formatter is hard-coded to use \r\n for line breaks
+  private final String newLine = "\r\n";
+
+  @Before
+  public void setUp() throws Exception {
+    // start the server
+    server = Main.startServer();
+
+    // create the client
+    Client c = ClientBuilder.newBuilder().register(MultiPartFeature.class).build();
+    target = c.target(Main.BASE_URI.replace("0.0.0.0", "localhost"));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.shutdownNow();
+  }
+
+  @Test
+  public void testUnformattedLibrary() {
+    String input = "library HelloWorld using QDM define Hello: 'World'";
+    Response resp = target.path("formatter").request(FormatterResource.CQL_TEXT_TYPE).post(Entity.entity(input, FormatterResource.CQL_TEXT_TYPE));
+    assertEquals(Status.OK.getStatusCode(), resp.getStatus());
+    assertEquals(FormatterResource.CQL_TEXT_TYPE, resp.getMediaType().toString());
+    assertTrue(resp.hasEntity());
+    String actual = resp.readEntity(String.class);
+    String expected = String.join(
+      newLine,
+      "library HelloWorld",
+      "",
+      "using QDM",
+      "",
+      "define Hello:",
+      "  'World'"
+    );
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testInvalidCql() {
+    String input = "lib HelloWorld using QDM define Hello: 'World'";
+    Response resp = target.path("formatter").request(FormatterResource.CQL_TEXT_TYPE).post(Entity.entity(input, FormatterResource.CQL_TEXT_TYPE));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+    assertEquals("text/plain", resp.getMediaType().toString());
+    assertTrue(resp.hasEntity());
+    String actual = resp.readEntity(String.class);
+    assertTrue(actual.startsWith("CQL formatting failed due to errors:[1:0]: mismatched input 'lib'"));
+  }
+
+  @Test
+  public void testSingleUnformattedLibraryAsMultipart() {
+    String input = "library HelloWorld2 using QDM define Hello: 'World2'";
+    FormDataMultiPart pkg = new FormDataMultiPart();
+    pkg.field("foo", input, new MediaType("application", "cql"));
+    Response resp = target.path("formatter").request(MediaType.MULTIPART_FORM_DATA).post(Entity.entity(pkg, MediaType.MULTIPART_FORM_DATA));
+    assertEquals(Status.OK.getStatusCode(), resp.getStatus());
+    assertEquals(MediaType.MULTIPART_FORM_DATA_TYPE.getType(), resp.getMediaType().getType());
+    assertEquals(MediaType.MULTIPART_FORM_DATA_TYPE.getSubtype(), resp.getMediaType().getSubtype());
+    assertTrue(resp.hasEntity());
+    FormDataMultiPart translatedPkg = resp.readEntity(FormDataMultiPart.class);
+    assertEquals(1, translatedPkg.getBodyParts().size());
+    assertEquals(1, translatedPkg.getFields("foo").size());
+    String actual = translatedPkg.getBodyParts().get(0).getEntityAs((String.class));
+    String expected = String.join(
+      newLine,
+      "library HelloWorld2",
+      "",
+      "using QDM",
+      "",
+      "define Hello:",
+      "  'World2'"
+    );
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testTwoUnformattedLibrariesAsMultipart() {
+    String input = "library HelloWorld3 using FHIR define Hello: 'World3'";
+    String input2 = "library FHIRHelpers version '4.0.1' using FHIR version '4.0.1'\n" +
+      "context Patient define \"IsFakeFHIRHelpers\": true";
+    FormDataMultiPart pkg = new FormDataMultiPart();
+    pkg.field("foo", input, new MediaType("application", "cql"));
+    pkg.field("zoo", input2, new MediaType("application", "cql"));
+    Response resp = target.path("formatter").request(MediaType.MULTIPART_FORM_DATA).post(Entity.entity(pkg, MediaType.MULTIPART_FORM_DATA));
+    assertEquals(Status.OK.getStatusCode(), resp.getStatus());
+    assertEquals(MediaType.MULTIPART_FORM_DATA_TYPE.getType(), resp.getMediaType().getType());
+    assertEquals(MediaType.MULTIPART_FORM_DATA_TYPE.getSubtype(), resp.getMediaType().getSubtype());
+    assertTrue(resp.hasEntity());
+    FormDataMultiPart translatedPkg = resp.readEntity(FormDataMultiPart.class);
+    assertEquals(2, translatedPkg.getBodyParts().size());
+    assertEquals(1, translatedPkg.getFields("foo").size());
+    String actual = translatedPkg.getBodyParts().get(0).getEntityAs((String.class));
+    String expected = String.join(
+      newLine,
+      "library HelloWorld3",
+      "",
+      "using FHIR",
+      "",
+      "define Hello:",
+      "  'World3'"
+    );
+    assertEquals(expected, actual);
+    assertEquals(1, translatedPkg.getFields("zoo").size());
+    String actual2 = translatedPkg.getBodyParts().get(1).getEntityAs((String.class));
+    String expected2 = String.join(
+      newLine,
+      "library FHIRHelpers version '4.0.1'",
+      "",
+      "using FHIR version '4.0.1'",
+      "",
+      "context Patient",
+      "",
+      "define \"IsFakeFHIRHelpers\":",
+      "  true"
+    );
+    assertEquals(expected2, actual2);
+  }
+
+  @Test
+  public void testInvalidCqlInMultipart() {
+    String input = "library HelloWorld3 using FHIR define Hello: 'World3'";
+    String input2 = "library FHIRHelpers version '4.0.1' using FHIR version '4.0.1'\n" +
+      "ctx Patient define \"IsFakeFHIRHelpers\": true";
+    FormDataMultiPart pkg = new FormDataMultiPart();
+    pkg.field("foo", input, new MediaType("application", "cql"));
+    pkg.field("zoo", input2, new MediaType("application", "cql"));
+    Response resp = target.path("formatter").request(MediaType.MULTIPART_FORM_DATA).post(Entity.entity(pkg, MediaType.MULTIPART_FORM_DATA));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+    assertEquals("text/plain", resp.getMediaType().toString());
+    assertTrue(resp.hasEntity());
+    String actual = resp.readEntity(String.class);
+    System.out.println(actual);
+    assertTrue(actual.startsWith("CQL formatting failed due to errors:[2:0]: extraneous input 'ctx'"));
+  }
+}
+

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -192,11 +192,10 @@ public class TranslationResourceTest {
     assertEquals(2, annotations.size());
     JsonObject errorAnnotation = annotations.getJsonObject(1);
     assertEquals("CqlToElmError", errorAnnotation.getString("type"));
-    assertEquals("include", errorAnnotation.getString("errorType"));
+    assertEquals("semantic", errorAnnotation.getString("errorType"));
     assertEquals(5, errorAnnotation.getInt("startLine"));
     assertEquals(1, errorAnnotation.getInt("startChar"));
-    assertEquals("CMSAll", errorAnnotation.getString("targetIncludeLibraryId"));
-    assertEquals("1", errorAnnotation.getString("targetIncludeLibraryVersionId"));
+    assertEquals("Could not load source for library CMSAll, version 1.", errorAnnotation.getString("message"));
   }
 
   @Test

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -3,7 +3,6 @@ package org.mitre.bonnie.cqlTranslationServer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -416,7 +415,7 @@ public class TranslationResourceTest {
     }
 
     @Override
-    public Iterator getPrefixes(String uri) {
+    public Iterator<String> getPrefixes(String uri) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
This PR adds a new `/cql/formatter` endpoint to the service that uses the CQL formatter Java library.  The endpoint can accept a standard post of a single CQL library (w/ Content-Type `application/cql`) or a multi-part post with multiple CQL libraries. It will return a standard or multi-part response based on the input request.  If there are errors formatting the CQL, it will respond w/ an HTTP error code and the relevant error message.

To test this, you need Java and Maven installed. I am using Java 11 and Maven 3.8.5.  On Mac, Maven can be installed via `brew install maven`.  First build the package (which also runs the tests):
```sh
$ mvn package
```
Then to run the translator, issue this command:
```sh
$ java -jar target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar
```
_NOTE: If you already have a release of the translator running (for example, via Docker), you'll need to stop it first._

Once you have it running, you can use a RESTful client to send the following unformatted CQL to the endpoint `http://localhost:8080/cql/formatter`:
```
library HelloWorld using QDM define Hello: 'World'
```
You should get back a formatted response like this:
```
library HelloWorld

using QDM

define Hello:
  'World'
```

If you just want to use curl, you can try this:
```
curl --request POST \
  --url http://localhost:8080/cql/formatter \
  --header 'Accept: application/cql' \
  --header 'Content-Type: application/cql' \
  --data 'library HelloWorld using QDM define Hello: '\''World'\'''
```
Or multi-part:
```
curl --request POST \
  --url http://localhost:8080/cql/formatter \
  --header 'Accept: multipart/form-data' \
  --header 'Content-Type: multipart/form-data' \
  --form 'Simple.cql=library "SimpleLibrary" version '\''0.0.1'\'' using FHIR version '\''4.0.1'\''
include "FHIRHelpers" version '\''4.0.1'\'' called FHIRHelpers
context Patient define "MeaningOfLife": 42
' \
  --form 'FHIRHelpers.cql=library FHIRHelpers version '\''4.0.1'\'' using FHIR version '\''4.0.1'\''
context Patient define "IsFakeFHIRHelpers": true
'
```