### PR TITLE
Docker Build and Publish Workflow

### DIFF
--- a/.github/workflows/docker-publish-workflow.yml
+++ b/.github/workflows/docker-publish-workflow.yml
@@ -1,0 +1,50 @@
+# Whenever a new release is published, this action will build a new Docker image
+# and push it to DockerHub. This action is based on the following documentation:
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+# https://github.com/docker/build-push-action/blob/master/docs/advanced/dockerhub-desc.md
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: cqframework/cql-translation-service
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+      -
+        name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: cqframework/cql-translation-service


### PR DESCRIPTION
Adding a new workflow that will build and publish a Docker image whenever we publish a new release on GitHub.

Unfortunately, there isn't a great way to test this without just doing it.  So the review should just be a look at the workflow file to ensure nothing seems too out of place.