### PR TITLE
Update CQLT, Java, Platform, Events

### DIFF
--- a/.github/workflows/docker-publish-workflow.yml
+++ b/.github/workflows/docker-publish-workflow.yml
@@ -6,6 +6,7 @@
 name: Publish Docker image
 
 on:
+  pull_request:
   release:
     types: [published]
 
@@ -39,9 +40,11 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
       -
+        if: github.event_name == "release"
         name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         with:

--- a/.github/workflows/docker-publish-workflow.yml
+++ b/.github/workflows/docker-publish-workflow.yml
@@ -44,7 +44,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
       -
-        if: github.event_name == "release"
+        if: github.event_name == 'release'
         name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.6.1-jdk-8
+FROM maven:3.8.6-eclipse-temurin-11
 
 # application placed into /opt/app
 RUN mkdir -p /app
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-1.5.12-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.5.10-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-1.5.12-jar-with-dependencies.jar
 
 ## Translator Endpoint
 
@@ -277,9 +277,15 @@ You may deploy pre-built Docker images into your existing hosting environment wi
 
 And you're done. No environment variables or further configuration are needed. Jedis may use your existing Kubernetes, Open Shift etc installations as you see fit. :)
 
-To build your own image:
+To build your own image for your current architecture:
 
 	docker build -t cqframework/cql-translation-service:latest . # but use your your own repo and tag strings!
+
+To build your own image for multiple architectures (e.g., Intel and Mac M1):
+
+  docker buildx build --platform linux/amd64,linux/arm64 -t cqframework/cql-translation-service:latest . # but use your your own repo and tag strings!
+
+Note that Docker doesn't support loading multi-platform builds locally, so the above multi-platform build commmand is only helpful when used with `--push`. See: [https://github.com/docker/buildx/issues/59](https://github.com/docker/buildx/issues/59).
 
 ## Environment Variables
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.10</version>
+  <version>1.5.12</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -70,37 +70,37 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.5.10</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.5.10</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.5.10</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.5.10</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.5.10</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>qdm</artifactId>
-		  <version>1.5.10</version>
+		  <version>1.5.12</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>cql-formatter</artifactId>
-		  <version>1.5.10</version>
+		  <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
The primary purpose of this PR is to update the CQL Translation Service Docker image to support multiple platforms. Prior to this PR, the CQL Translation Service Docker image did not run well on Mac M1 devices.

In addition to adding support for multi-platform (AMD/ARM) Docker images, this PR also introduces the following changes:
* Upate CQL Translator to 1.5.12
* Update Java to Temurin 11
* Update Docker Publish action to trigger on PRs

Thanks to the last change listed above, you can now test this PR by pulling its image from DockerHub. To test it:
1. Ensure you don't already have cql-to-elm running somewhere else
2. Ensure you don't have anything else listening on port 8080
3. Run:
    ```
    docker run -p 8080:8080 cqframework/cql-translation-service:pr-33
    ```
4. Test it using Insomnia, Postman, or your favorite REST testing tool
5. Stop it using `<Control-C>`

I've tested and confirmed it works on M1, so I especially appreciate a confirmation that it works on Intel processors.