### PR TITLE
Support for CQL Translator 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.8.6-eclipse-temurin-11
+FROM maven:3.9.0-eclipse-temurin-11
 
 # application placed into /opt/app
 RUN mkdir -p /app
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-1.5.12-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.7.0-jar-with-dependencies.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-1.5.12-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-2.7.0-jar-with-dependencies.jar
 
 ## Translator Endpoint
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.12</version>
+  <version>2.7.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -59,53 +59,58 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.11.0.Final</version>
+      <version>3.12.1.Final</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.9</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.5.12</version>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.5.12</version>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.5.12</version>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
-      <artifactId>elm</artifactId>
-      <version>1.5.12</version>
+      <artifactId>model-jaxb</artifactId>
+      <version>${cql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>info.cqframework</groupId>
+      <artifactId>elm-jaxb</artifactId>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.5.12</version>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>qdm</artifactId>
-		  <version>1.5.12</version>
+		  <version>${cql.version}</version>
     </dependency>
     <dependency>
 		  <groupId>info.cqframework</groupId>
 		  <artifactId>cql-formatter</artifactId>
-		  <version>1.5.12</version>
+		  <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 
@@ -117,14 +122,14 @@
         <version>2.5.1</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.0</version>
         <executions>
           <execution>
             <goals>
@@ -163,7 +168,8 @@
   </build>
 
   <properties>
-    <jersey.version>2.32</jersey.version>
+    <cql.version>2.7.0</cql.version>
+    <jersey.version>2.39.1</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationFailureException.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationFailureException.java
@@ -5,12 +5,9 @@
  */
 package org.mitre.bonnie.cqlTranslationServer;
 
-import java.util.List;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
-import org.cqframework.cql.elm.tracking.TrackBack;
 
 /**
  *
@@ -25,25 +22,5 @@ public class TranslationFailureException extends WebApplicationException {
             .type(MediaType.TEXT_PLAIN_TYPE)
             .entity(msg)
             .build());
-  }
-
-  public TranslationFailureException(List<CqlTranslatorException> translationErrs) {
-    super(Response.status(Response.Status.BAD_REQUEST)
-            .type(MediaType.TEXT_PLAIN_TYPE)
-            .entity(formatMsg(translationErrs))
-            .build());
-  }
-
-  private static String formatMsg(List<CqlTranslatorException> translationErrs) {
-    StringBuilder msg = new StringBuilder();
-    msg.append("Translation failed due to errors:");
-    for (CqlTranslatorException error : translationErrs) {
-      TrackBack tb = error.getLocator();
-      String lines = tb == null ? "[n/a]" : String.format("[%d:%d, %d:%d]",
-              tb.getStartLine(), tb.getStartChar(), tb.getEndLine(),
-              tb.getEndChar());
-      msg.append(String.format("%s %s%n", lines, error.getMessage()));
-    }
-    return msg.toString();
   }
 }

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -191,7 +191,7 @@ public class TranslationResourceTest {
     assertEquals(2, annotations.size());
     JsonObject errorAnnotation = annotations.getJsonObject(1);
     assertEquals("CqlToElmError", errorAnnotation.getString("type"));
-    assertEquals("semantic", errorAnnotation.getString("errorType"));
+    assertEquals("include", errorAnnotation.getString("errorType"));
     assertEquals(5, errorAnnotation.getInt("startLine"));
     assertEquals(1, errorAnnotation.getInt("startChar"));
     assertEquals("Could not load source for library CMSAll, version 1.", errorAnnotation.getString("message"));


### PR DESCRIPTION
The PR adds support for CQL-to-ELM 2.7. This required changes to the code, including:
* adding `model-jaxb` dependency
* changing elm dependency to `elm-jaxb`
* Changing `CqlTransaltorException` to `CqlCompilerException`
* Registering all the model info providers up front
* ... other minor changes

This should work using all three of the following approaches:
1. Run `mvn exec:java`
2. Run `mvn package` followed by `java -jar target/cqlTranslationServer-2.7.0-jar-with-dependencies.jar`
3. Build Docker image and run Docker container (see README)