### PR TITLE
v2.0.0: Ditch the uber-jar and use semantic versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.7.0-jar-with-dependencies.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.0.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.7.0-jar-with-dependencies.jar
+    java -jar target/cqlTranslationServer-2.0.0.jar
+
+_NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `lib` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/lib` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
+
+## Version Table
+
+CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL Tools (CQL-to-ELM translator) version they exposed. Starting with version 2.0.0, semantic versioning is now used. As a result, the version of the CQL Translation Service differs from the version of the CQL Tools that it exposes. The following table shows the relationship between [CQL Translation Service releases](https://github.com/cqframework/cql-translation-service/releases) and [CQL Tools releases](https://github.com/cqframework/clinical_quality_language/releases). Note that prior releases from the [MITRE repo](https://github.com/mitre/cql-translation-service/releases) are not included here.
+
+| CQL Translation Service | CQL Tools                               |
+|-------------------------|-----------------------------------------|
+| 2.0.0                   | 2.7.0                                   |
+| 1.1.0-SNAPSHOT - 1.5.12 | Matches CQL Translation Service version |
+| 1.0.2                   | 1.0.0                                   |
 
 ## Translator Endpoint
 
@@ -176,7 +188,7 @@ For more information on each of these options, see the [CQL-to-ELM Overview](htt
 
 _**NOTE:**_
 * _Previous versions of the CQL-to-ELM Translation Service defaulted **annotations** to true.  To align better with the CQL-to-ELM console client, the translation service now defaults annotations to false._
-* _Previous versions of the CQL-to-ELM Translation Service allowed list-promotion to be disabled via an extra multipart form field named **disablePromotion**. This is no longer supported, as it was ambiguous and inconsistent with the CQL-to-ELM console clinet.  The **disable-list-promotion** query parameter should be used instead._
+* _Previous versions of the CQL-to-ELM Translation Service allowed list-promotion to be disabled via an extra multipart form field named **disablePromotion**. This is no longer supported, as it was ambiguous and inconsistent with the CQL-to-ELM console client.  The **disable-list-promotion** query parameter should be used instead._
 
 ## Formatter Endpoint
 
@@ -293,7 +305,7 @@ Note that Docker doesn't support loading multi-platform builds locally, so the a
 
 ## License
 
-Copyright 2016-2022 The MITRE Corporation
+Copyright 2016-2023 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -119,17 +119,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <inherited>true</inherited>
+        <version>3.11.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <goals>
@@ -141,9 +139,10 @@
           <mainClass>org.mitre.bonnie.cqlTranslationServer.Main</mainClass>
         </configuration>
       </plugin>
-       <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -152,6 +151,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
+              <includeScope>runtime</includeScope>
               <outputDirectory>${project.build.directory}/libs</outputDirectory>
             </configuration>
           </execution>
@@ -160,6 +160,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.7.0</version>
+  <version>2.0.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -98,14 +98,14 @@
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-		  <groupId>info.cqframework</groupId>
-		  <artifactId>qdm</artifactId>
-		  <version>${cql.version}</version>
+      <groupId>info.cqframework</groupId>
+      <artifactId>qdm</artifactId>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
-		  <groupId>info.cqframework</groupId>
-		  <artifactId>cql-formatter</artifactId>
-		  <version>${cql.version}</version>
+      <groupId>info.cqframework</groupId>
+      <artifactId>cql-formatter</artifactId>
+      <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -141,28 +141,34 @@
           <mainClass>org.mitre.bonnie.cqlTranslationServer.Main</mainClass>
         </configuration>
       </plugin>
-      <!-- This builds the "uberjar" that can be used with java -jar to run -->
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/libs</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-jar-plugin</artifactId>
         <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
           <archive>
             <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>libs/</classpathPrefix>
               <mainClass>org.mitre.bonnie.cqlTranslationServer.Main</mainClass>
             </manifest>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -22,16 +22,10 @@ import javax.ws.rs.core.UriInfo;
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions.Options;
-import org.cqframework.cql.cql2elm.qdm.QdmModelInfoProvider;
 import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
-import org.cqframework.cql.cql2elm.quick.FhirModelInfoProvider;
-import org.cqframework.cql.cql2elm.quick.QICoreModelInfoProvider;
-import org.cqframework.cql.cql2elm.quick.QuickFhirModelInfoProvider;
-import org.cqframework.cql.cql2elm.quick.QuickModelInfoProvider;
-import org.cqframework.cql.cql2elm.quick.UsCoreModelInfoProvider;
 import org.fhir.ucum.UcumEssenceService;
 import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
@@ -80,14 +74,6 @@ public class TranslationResource {
 
   public TranslationResource() {
     this.modelManager = new ModelManager();
-    // The DefaultModelInfoProvider does not work correctly with the uber-jar and in-memory CQL files, so
-    // load all the models we might want. Model resolution is attempted in the order the providers are added.
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new FhirModelInfoProvider(), true);
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new QICoreModelInfoProvider());
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new QdmModelInfoProvider());
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new QuickModelInfoProvider());
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new QuickFhirModelInfoProvider());
-    modelManager.getModelInfoLoader().registerModelInfoProvider(new UsCoreModelInfoProvider());
     this.libraryManager = new LibraryManager(modelManager);
     // FHIR library source provider is always needed for FHIR and harmless for other models
     libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());


### PR DESCRIPTION
CQL tools libraries do not function well within an uber jar. For example:
- Default model info provision does not work
- Version reporting (in annotations) does not work

When a standard classpath is used instead (pointing to a folder containing dependency libraries), everything works better. This commit removes the uber jar and uses a standard classpath instead.

This commit also changes the version number to 2.0.0 and introduces the new semantic versioning scheme.

**To TEST:**

Run some translations and confirm they still work (despite my having removed all the explicit ModelInfoProviders). If possible, try a translation using another supported model (like QDM).

Note that the first annotation now reports the translator version, e.g.:
```json
{
  "translatorVersion": "2.7.0",
  "translatorOptions": "",
  "type": "CqlToElmInfo"
}
```

If you pass in options (e.g., `?annotations=true&locators=true`), you should see them listed as well. E.g.:
```json
{
  "translatorVersion": "2.7.0",
  "translatorOptions": "EnableAnnotations,EnableLocators",
  "type": "CqlToElmInfo"
}
```