### PR TITLE
Version 2.1.0 with Translator 2.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.0.0.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.1.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.0.0.jar
+    java -jar target/cqlTranslationServer-2.1.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 |-------------------------|-----------------------------------------|
+| 2.1.0                   | 2.10.0                                  |
 | 2.0.0                   | 2.7.0                                   |
 | 1.1.0-SNAPSHOT - 1.5.12 | Matches CQL Translation Service version |
 | 1.0.2                   | 1.0.0                                   |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -175,7 +175,7 @@
   </build>
 
   <properties>
-    <cql.version>2.7.0</cql.version>
+    <cql.version>2.10.0</cql.version>
     <jersey.version>2.39.1</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Updates the translator to version [2.10.0](https://github.com/cqframework/clinical_quality_language/releases/tag/v2.10.0).

Bumps its own version to version 2.1.0.

You can test the Docker image for this PR by running the following command:
```
docker run -p 8080:8080 cqframework/cql-translation-service:pr-37
```