### PR TITLE
Translator 2.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.9.0-eclipse-temurin-11
+FROM maven:3.9.5-eclipse-temurin-11
 
 # application placed into /opt/app
 RUN mkdir -p /app
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.1.0.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.2.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.1.0.jar
+    java -jar target/cqlTranslationServer-2.2.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 |-------------------------|-----------------------------------------|
+| 2.2.0                   | 2.11.0                                  |
 | 2.1.0                   | 2.10.0                                  |
 | 2.0.0                   | 2.7.0                                   |
 | 1.1.0-SNAPSHOT - 1.5.12 | Matches CQL Translation Service version |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.12.1.Final</version>
+      <version>3.15.6.Final</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 
@@ -175,8 +175,8 @@
   </build>
 
   <properties>
-    <cql.version>2.10.0</cql.version>
-    <jersey.version>2.39.1</jersey.version>
+    <cql.version>2.11.0</cql.version>
+    <jersey.version>2.41</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
This updates to CQL Translator to v2.11.0 and bumps dependencies to their latest minor/patch versions (without upgrading any major versions).

While the latest CQL Translator is v3.3.2, I wanted to get out a version representing the _last_ 2.x release before moving to 3.x.

You can test this by building locally or you can test using the Docker image corresponding to this PR, e.g.:
```
$ docker run -p 8080:8080 cqframework/cql-translation-service:pr-38
```