### PR TITLE
Version 2.3.0 w/ support for Translator 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.2.0.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.3.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.2.0.jar
+    java -jar target/cqlTranslationServer-2.3.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 |-------------------------|-----------------------------------------|
+| 2.3.0                   | 3.3.2                                   |
 | 2.2.0                   | 2.11.0                                  |
 | 2.1.0                   | 2.10.0                                  |
 | 2.0.0                   | 2.7.0                                   |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -175,7 +175,7 @@
   </build>
 
   <properties>
-    <cql.version>2.11.0</cql.version>
+    <cql.version>3.3.2</cql.version>
     <jersey.version>2.41</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Update the translator to the latest one in the 3.x line. This required code changes, as the Translator classes have been refactored. The basic use and API of the service, however, has not changed, so this is only a minor bump in regard to the service version.