### PR TITLE
Version 2.7.0 (supporting Translator 3.22.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.9.5-eclipse-temurin-11
+FROM maven:3.9.9-eclipse-temurin-11
 
 # application placed into /opt/app
 RUN mkdir -p /app
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.6.0.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.7.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.6.0.jar
+    java -jar target/cqlTranslationServer-2.7.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 | ----------------------- | --------------------------------------- |
+| 2.7.0                   | 3.22.0                                  |
 | 2.6.0                   | 3.18.0                                  |
 | 2.5.0                   | 3.15.0                                  |
 | 2.4.0                   | 3.7.1                                   |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.6.0</version>
+  <version>2.7.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -181,7 +181,7 @@
   </build>
 
   <properties>
-    <cql.version>3.18.0</cql.version>
+    <cql.version>3.22.0</cql.version>
     <jersey.version>3.1.8</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Bump Translator to version 3.22.0. Also bump Docker base image to Maven 3.9.9.