### PR TITLE
Upgrade to the new CQL-to-ELM 4.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn --batch-mode verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.9.9-eclipse-temurin-11
+FROM maven:3.9.9-eclipse-temurin-17
 
 # application placed into /opt/app
 RUN mkdir -p /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.9.9-eclipse-temurin-17
+FROM maven:3.9.9-eclipse-temurin-11
 
 # application placed into /opt/app
 RUN mkdir -p /app
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.6.0.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.7.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.6.0.jar
+    java -jar target/cqlTranslationServer-2.7.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 | ----------------------- | --------------------------------------- |
+| 2.7.0                   | 3.22.0                                  |
 | 2.6.0                   | 3.18.0                                  |
 | 2.5.0                   | 3.15.0                                  |
 | 2.4.0                   | 3.7.1                                   |

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <repository>
       <id>sonatype-snapshot</id>
       <name>Sonatype Snapshot</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.6.0</version>
+  <version>2.7.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -90,16 +90,6 @@
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
-      <artifactId>model-xmlutil</artifactId>
-      <version>${cql.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>info.cqframework</groupId>
-      <artifactId>elm-xmlutil</artifactId>
-      <version>${cql.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
       <version>${cql.version}</version>
     </dependency>
@@ -117,12 +107,6 @@
       <groupId>info.cqframework</groupId>
       <artifactId>cql-formatter</artifactId>
       <version>${cql.version}</version>
-    </dependency>
-    <!-- Include xmlutil 0.91.0-RC1 because the snapshot cql-to-elm declares is not resolving -->
-    <dependency>
-      <groupId>io.github.pdvrieze.xmlutil</groupId>
-      <artifactId>serialization-jvm</artifactId>
-      <version>0.91.0-RC1</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -77,7 +77,7 @@ public class TranslationResource {
   public Response cqlToElmXml(File cql, @Context UriInfo info) {
     try {
       LibraryManager libraryManager = this.getLibraryManager(info.getQueryParameters());
-      CqlTranslator translator = CqlTranslator.fromFile(cql, libraryManager);
+      CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(cql), libraryManager);
       ResponseBuilder resp = getResponse(translator);
       resp = resp.entity(translator.toXml()).type(ELM_XML_TYPE);
       return resp.build();
@@ -93,7 +93,7 @@ public class TranslationResource {
   public Response cqlToElmJson(File cql, @Context UriInfo info) {
     try {
       LibraryManager libraryManager = this.getLibraryManager(info.getQueryParameters());
-      CqlTranslator translator = CqlTranslator.fromFile(cql, libraryManager);
+      CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(cql), libraryManager);
       ResponseBuilder resp = getResponse(translator);
       resp = resp.entity(translator.toJson()).type(ELM_JSON_TYPE);
       return resp.build();
@@ -118,7 +118,7 @@ public class TranslationResource {
       FormDataMultiPart translatedPkg = new FormDataMultiPart();
       for (String fieldId: pkg.getFields().keySet()) {
         for (FormDataBodyPart part: pkg.getFields(fieldId)) {
-          CqlTranslator translator = CqlTranslator.fromFile(part.getEntityAs(File.class), libraryManager);
+          CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(part.getEntityAs(File.class)), libraryManager);
           for( String format : targetFormats ) {
             for( String subformat : format.split(",") ) {
               MediaType targetFormat = MediaType.valueOf( subformat );

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -195,7 +195,7 @@ public class TranslationResourceTest {
     assertEquals("include", errorAnnotation.getString("errorType"));
     assertEquals(5, errorAnnotation.getInt("startLine"));
     assertEquals(1, errorAnnotation.getInt("startChar"));
-    assertTrue(errorAnnotation.getString("message").matches("Could not load source for library CMSAll,\\s+version 1."));
+    assertEquals("Could not load source for library CMSAll, version 1, namespace uri null.", errorAnnotation.getString("message"));
   }
 
   @Test
@@ -313,7 +313,6 @@ public class TranslationResourceTest {
     }
   }
 
-  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsXml() throws Exception {
     String filenames[] = {"valid.cql"};
@@ -338,7 +337,6 @@ public class TranslationResourceTest {
     }
   }
 
-  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsJsonAndXml() throws Exception {
     String filenames[] = {"valid.cql"};

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -41,7 +41,6 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;


### PR DESCRIPTION
The new CQL-to-ELM 4.0.0-SNAPSHOT includes serialization fixes and does not depend on XmlUtil.

This PR updates the kotlin-snapshot-upgrade branch and re-enables the tests which previously failed.