### PR TITLE
info.cqframework->org.cqframework, Formatter change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,27 +84,27 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>quick</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>qdm</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>ucum</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>cql-formatter</artifactId>
       <version>${cql.version}</version>
     </dependency>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
@@ -14,7 +14,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import org.cqframework.cql.tools.formatter.Main;
 import org.cqframework.cql.tools.formatter.CqlFormatterVisitor;
+import org.cqframework.cql.tools.formatter.CqlFormatterVisitor.Companion;
 import org.cqframework.cql.tools.formatter.CqlFormatterVisitor.FormatResult;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -35,7 +37,7 @@ public class FormatterResource {
     FileInputStream is = null;
     try {
       is = new FileInputStream(cql);
-      FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+      FormatResult result = CqlFormatterVisitor.Companion.getFormattedOutput(is);
       if( result.getErrors() != null && result.getErrors().size() > 0 ) {
         throw new FormatFailureException(result.getErrors());
       }
@@ -69,7 +71,7 @@ public class FormatterResource {
           FileInputStream is = null;
           try {
             is = new FileInputStream(part.getEntityAs(File.class));
-            FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+            FormatResult result = CqlFormatterVisitor.Companion.getFormattedOutput(is);
             if( result.getErrors() != null && result.getErrors().size() > 0 ) {
                 throw new FormatFailureException(result.getErrors());
             }


### PR DESCRIPTION
## Summary
Updating the `kotlin-snapshot-upgrade` branch since updates were recently made in [clinical_quality_language](https://github.com/cqframework/clinical_quality_language), particularly the following two PRs getting merged:
- https://github.com/cqframework/clinical_quality_language/pull/1613
- https://github.com/cqframework/clinical_quality_language/pull/1612

## Code changes
- `pom.xml` - `info.cqframework` to `org.cqframework` 
- `FormatterResource.java` - in [this PR](https://github.com/cqframework/clinical_quality_language/pull/1612), the structure of CqlFormatterVisitor was changed so `Companion` was needed in order to use the `getFormattedOutput` function.