### PR TITLE
Translator 4.2.0

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn --batch-mode verify

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+java temurin-17.0.14+7
+maven 3.9.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # fetch basic image
-FROM maven:3.9.9-eclipse-temurin-11
+FROM maven:3.9.9-eclipse-temurin-17
 
 # application placed into /opt/app
 RUN mkdir -p /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080
 
 # execute it
 # CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.7.1.jar", "-d"]
+CMD ["java", "-jar", "target/cqlTranslationServer-2.8.0.jar", "-d"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 
 Execute via the command line:
 
-    java -jar target/cqlTranslationServer-2.7.0.jar
+    java -jar target/cqlTranslationServer-2.8.0.jar
 
 _NOTE: The cqlTranslationServer jar assumes that all dependency jars are located in a `libs` directory relative to the jar's location. If you move the jar from the `target` directory, you will need to move the `target/libs` directory as well. This project no longer produces an "uber-jar", as the CQL-to-ELM classes do not function properly when repackaged into a single jar file._
 
@@ -18,6 +18,7 @@ CQL Translation Service versions prior to version 2.0.0 always mirrored the CQL 
 
 | CQL Translation Service | CQL Tools                               |
 | ----------------------- | --------------------------------------- |
+| 2.8.0                   | 4.2.0                                   |
 | 2.7.x                   | 3.22.0                                  |
 | 2.6.0                   | 3.18.0                                  |
 | 2.5.0                   | 3.15.0                                  |

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,16 @@
       <name>Sonatype Public</name>
       <url>https://oss.sonatype.org/content/groups/public/</url>
     </repository>
+    <repository>
+      <id>sonatype-releases</id>
+      <name>Sonatype Releases</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/releases/</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshot</id>
+      <name>Sonatype Snapshot</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
   </repositories>
 
   <dependencyManagement>
@@ -80,12 +90,12 @@
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
-      <artifactId>model-jaxb</artifactId>
+      <artifactId>model-xmlutil</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
-      <artifactId>elm-jaxb</artifactId>
+      <artifactId>elm-xmlutil</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
@@ -100,8 +110,19 @@
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
+      <artifactId>ucum</artifactId>
+      <version>${cql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>info.cqframework</groupId>
       <artifactId>cql-formatter</artifactId>
       <version>${cql.version}</version>
+    </dependency>
+    <!-- Include xmlutil 0.91.0-RC1 because the snapshot cql-to-elm declares is not resolving -->
+    <dependency>
+      <groupId>io.github.pdvrieze.xmlutil</groupId>
+      <artifactId>serialization-jvm</artifactId>
+      <version>0.91.0-RC1</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -172,6 +193,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathPrefix>libs/</classpathPrefix>
+              <useUniqueVersions>false</useUniqueVersions>
               <mainClass>org.mitre.bonnie.cqlTranslationServer.Main</mainClass>
             </manifest>
           </archive>
@@ -181,7 +203,7 @@
   </build>
 
   <properties>
-    <cql.version>3.22.0</cql.version>
+    <cql.version>4.0.0-SNAPSHOT</cql.version>
     <jersey.version>3.1.8</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,27 +84,27 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>quick</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>qdm</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>ucum</artifactId>
       <version>${cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>info.cqframework</groupId>
+      <groupId>org.cqframework</groupId>
       <artifactId>cql-formatter</artifactId>
       <version>${cql.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <repository>
       <id>sonatype-snapshot</id>
       <name>Sonatype Snapshot</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </repository>
   </repositories>
 
@@ -90,16 +90,6 @@
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
-      <artifactId>model-xmlutil</artifactId>
-      <version>${cql.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>info.cqframework</groupId>
-      <artifactId>elm-xmlutil</artifactId>
-      <version>${cql.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
       <version>${cql.version}</version>
     </dependency>
@@ -117,12 +107,6 @@
       <groupId>info.cqframework</groupId>
       <artifactId>cql-formatter</artifactId>
       <version>${cql.version}</version>
-    </dependency>
-    <!-- Include xmlutil 0.91.0-RC1 because the snapshot cql-to-elm declares is not resolving -->
-    <dependency>
-      <groupId>io.github.pdvrieze.xmlutil</groupId>
-      <artifactId>serialization-jvm</artifactId>
-      <version>0.91.0-RC1</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.mitre.bonnie</groupId>
   <artifactId>cqlTranslationServer</artifactId>
   <packaging>jar</packaging>
-  <version>2.7.1</version>
+  <version>2.8.0</version>
   <name>cqlTranslationServer</name>
 
   <repositories>
@@ -187,7 +187,7 @@
   </build>
 
   <properties>
-    <cql.version>4.0.0-SNAPSHOT</cql.version>
+    <cql.version>4.2.0</cql.version>
     <jersey.version>3.1.8</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/FormatterResource.java
@@ -14,7 +14,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import org.cqframework.cql.tools.formatter.Main;
 import org.cqframework.cql.tools.formatter.CqlFormatterVisitor;
+import org.cqframework.cql.tools.formatter.CqlFormatterVisitor.Companion;
 import org.cqframework.cql.tools.formatter.CqlFormatterVisitor.FormatResult;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -35,7 +37,7 @@ public class FormatterResource {
     FileInputStream is = null;
     try {
       is = new FileInputStream(cql);
-      FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+      FormatResult result = CqlFormatterVisitor.Companion.getFormattedOutput(is);
       if( result.getErrors() != null && result.getErrors().size() > 0 ) {
         throw new FormatFailureException(result.getErrors());
       }
@@ -69,7 +71,7 @@ public class FormatterResource {
           FileInputStream is = null;
           try {
             is = new FileInputStream(part.getEntityAs(File.class));
-            FormatResult result = CqlFormatterVisitor.getFormattedOutput(is);
+            FormatResult result = CqlFormatterVisitor.Companion.getFormattedOutput(is);
             if( result.getErrors() != null && result.getErrors().size() > 0 ) {
                 throw new FormatFailureException(result.getErrors());
             }

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -77,7 +77,7 @@ public class TranslationResource {
   public Response cqlToElmXml(File cql, @Context UriInfo info) {
     try {
       LibraryManager libraryManager = this.getLibraryManager(info.getQueryParameters());
-      CqlTranslator translator = CqlTranslator.fromFile(cql, libraryManager);
+      CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(cql), libraryManager);
       ResponseBuilder resp = getResponse(translator);
       resp = resp.entity(translator.toXml()).type(ELM_XML_TYPE);
       return resp.build();
@@ -93,7 +93,7 @@ public class TranslationResource {
   public Response cqlToElmJson(File cql, @Context UriInfo info) {
     try {
       LibraryManager libraryManager = this.getLibraryManager(info.getQueryParameters());
-      CqlTranslator translator = CqlTranslator.fromFile(cql, libraryManager);
+      CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(cql), libraryManager);
       ResponseBuilder resp = getResponse(translator);
       resp = resp.entity(translator.toJson()).type(ELM_JSON_TYPE);
       return resp.build();
@@ -118,7 +118,7 @@ public class TranslationResource {
       FormDataMultiPart translatedPkg = new FormDataMultiPart();
       for (String fieldId: pkg.getFields().keySet()) {
         for (FormDataBodyPart part: pkg.getFields(fieldId)) {
-          CqlTranslator translator = CqlTranslator.fromFile(part.getEntityAs(File.class), libraryManager);
+          CqlTranslator translator = CqlTranslator.fromFile(new kotlinx.io.files.Path(part.getEntityAs(File.class)), libraryManager);
           for( String format : targetFormats ) {
             for( String subformat : format.split(",") ) {
               MediaType targetFormat = MediaType.valueOf( subformat );

--- a/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
+++ b/src/main/java/org/mitre/bonnie/cqlTranslationServer/TranslationResource.java
@@ -137,6 +137,10 @@ public class TranslationResource {
       return resp.build();
     } catch (IOException ex) {
       throw new TranslationFailureException("Unable to read request");
+    } catch (Exception ex) {
+      System.out.println("Thrown Exception: " + ex.getMessage());
+      ex.printStackTrace();
+      throw new TranslationFailureException("Other exception");
     }
   }
 

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -41,7 +41,6 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -195,7 +194,7 @@ public class TranslationResourceTest {
     assertEquals("include", errorAnnotation.getString("errorType"));
     assertEquals(5, errorAnnotation.getInt("startLine"));
     assertEquals(1, errorAnnotation.getInt("startChar"));
-    assertTrue(errorAnnotation.getString("message").matches("Could not load source for library CMSAll,\\s+version 1."));
+    assertEquals("Could not load source for library CMSAll, version 1, namespace uri null.", errorAnnotation.getString("message"));
   }
 
   @Test
@@ -313,7 +312,6 @@ public class TranslationResourceTest {
     }
   }
 
-  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsXml() throws Exception {
     String filenames[] = {"valid.cql"};
@@ -338,7 +336,6 @@ public class TranslationResourceTest {
     }
   }
 
-  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsJsonAndXml() throws Exception {
     String filenames[] = {"valid.cql"};

--- a/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
+++ b/src/test/java/org/mitre/bonnie/cqlTranslationServer/TranslationResourceTest.java
@@ -41,6 +41,7 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -194,7 +195,7 @@ public class TranslationResourceTest {
     assertEquals("include", errorAnnotation.getString("errorType"));
     assertEquals(5, errorAnnotation.getInt("startLine"));
     assertEquals(1, errorAnnotation.getInt("startChar"));
-    assertEquals("Could not load source for library CMSAll, version 1.", errorAnnotation.getString("message"));
+    assertTrue(errorAnnotation.getString("message").matches("Could not load source for library CMSAll,\\s+version 1."));
   }
 
   @Test
@@ -255,7 +256,7 @@ public class TranslationResourceTest {
 
   @Test
   void testInvalidListPromotionInAsJson() {
-    validateListPromotionDisabled("ListPromotionIn.cql", 7, 16, "Could not resolve call to operator In with signature (System.Integer,System.Integer).");
+    validateListPromotionDisabled("ListPromotionIn.cql", 7, 16, "Could not resolve call to operator In with signature (System.Integer, System.Integer).");
   }
 
   @Test
@@ -312,6 +313,7 @@ public class TranslationResourceTest {
     }
   }
 
+  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsXml() throws Exception {
     String filenames[] = {"valid.cql"};
@@ -336,6 +338,7 @@ public class TranslationResourceTest {
     }
   }
 
+  @Disabled("XML translation throws java.lang.IllegalStateException: 'Cache size exceeded expected bounds!'")
   @Test
   void testMultipartRequestAsJsonAndXml() throws Exception {
     String filenames[] = {"valid.cql"};


### PR DESCRIPTION
This PR upgrades the translator to the 4.2.0 translator that is expected to be used in MADiE. This upgrade required significant changes as it is the translation service's first use of the new Kotlin-based translator. Many thanks to @antvaset an @elsaperelli for their help!

To test:
* Run the unit tests and ensure they pass
* Deploy the service and test translation and format requests