### PR TITLE
Use Docker Hardened Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
-# fetch basic image
-FROM maven:3.9.9-eclipse-temurin-17
+###################################################################################################
+# Stage 1: Build the application
+###################################################################################################
 
-# application placed into /opt/app
-RUN mkdir -p /app
+FROM dhi.io/maven:3-jdk17-debian13-dev AS build
 WORKDIR /app
 
-# selectively add the POM file and
-# install dependencies
-COPY pom.xml /app/
-RUN mvn install
+# selectively add the POM file and install dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
 
-# rest of the project
-COPY src /app/src
+# add the src and package it
+COPY src src
 RUN mvn package
 
-# local application port
-EXPOSE 8080
+###################################################################################################
+# Stage 2: Create the final runtime image
+###################################################################################################
 
-# execute it
-# CMD ["mvn", "exec:java"]
-CMD ["java", "-jar", "target/cqlTranslationServer-2.9.0.jar", "-d"]
+FROM dhi.io/eclipse-temurin:17-debian13
+WORKDIR /app
+
+# copy the translation service jar and dependency libs from the previous build
+COPY --from=build /app/target/cqlTranslationServer-*.jar cqlTranslationServer.jar
+COPY --from=build /app/target/libs libs/
+
+# Expose the port and run it!
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/cqlTranslationServer.jar", "-d"]


### PR DESCRIPTION
Improve the Docker build in two ways:

1. Split the build into two stages: a build stage and a run stage. This allows us to publish a lighter JRE-based image that doesn't include a full JDK, maven, or any of the intermediate build artifacts.

2. Base the Docker build and run images on hardened images from dhi.io. This ensures a more secure final image.

~I was hoping that this could be tested using the automatically pushed Docker image w/ the `pr-52` tag, but Docker pushes in CI are failing due to corporate policy.~ To test locally run the following commands, substituting `<your-username>` for your real username (or really, anything you like):
1. Run `docker build -t <your-username>/cql-translation-service:pr-52 .`
2. Run `docker run -d -p 8080:8080 <your-username>/cql-translation-service:pr-52`

If you prefer to just pull the automatically pushed image for this PR, you can do this:
```
docker run -d -p 8080:8080 cqframework/cql-translation-service:pr-52
```
